### PR TITLE
fix: Fix test after Spinner implementation

### DIFF
--- a/src/components/ui/Spinner.test.js
+++ b/src/components/ui/Spinner.test.js
@@ -1,0 +1,11 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react';
+import Spinner from './Spinner';
+
+describe('Spinner component', () => {
+    test('renders loading text', () => {
+        render(<Spinner />);
+        const loadingText = screen.getByText('Loading ...');
+        expect(loadingText).toBeInTheDocument();
+    });
+});

--- a/src/pages/AllMeetupsPage.test.js
+++ b/src/pages/AllMeetupsPage.test.js
@@ -29,23 +29,38 @@ describe('AllMeetupsPage', () => {
         expect(headingElement).toBeInTheDocument();
     });
 
-    test('renders the list of meetups', () => {
+    test('renders the Spinner waiting for meetups', () => {
         const store = mockStore({
             meetups: mockMeetups,
             favorites: mockFavorites
-        });
+        })
 
         render(
             <Provider store={store}>
                 <AllMeetupsPage />
             </Provider>
         )
+        const spinner = screen.getByText('Loading ...');
+        expect(spinner).toBeInTheDocument();
+    });
 
+    test('renders the list of meetups', async () => {
+        const store = mockStore({
+            meetups: mockMeetups,
+            favorites: mockFavorites
+        })
+
+        render(
+            <Provider store={store}>
+                <AllMeetupsPage />
+            </Provider>
+        )
+        await screen.findAllByTestId('meet-up-item');
         const meetupItems = screen.getAllByTestId('meet-up-item');
         expect(meetupItems.length).toBe(mockMeetups.length);
     });
 
-    test('displays favorite text for favorite meetups', () => {
+    test('displays favorite text for favorite meetups', async () => {
         const store = mockStore({
             meetups: mockMeetups,
             favorites: mockFavorites
@@ -56,7 +71,7 @@ describe('AllMeetupsPage', () => {
                 <AllMeetupsPage />
             </Provider>
         );
-
+        await screen.findAllByTestId('meet-up-item');
         const favoriteIcon = screen.getByText('FAVORITE!');
         expect(favoriteIcon).toBeInTheDocument();
     });


### PR DESCRIPTION
Add async/await to some test in AllMeetupPage.test to wait for the meetups list. Add test to new Spinner component

Refs: #fix/17